### PR TITLE
add disqus integration

### DIFF
--- a/rtd_dropdown/base.html
+++ b/rtd_dropdown/base.html
@@ -114,6 +114,12 @@
               {% endblock %}
             </div>
           </div>
+          
+          <!-- Disqus integration -->
+          {% block disqus %}
+            {% include "integrations/disqus.html" %}
+          {% endblock %}
+
       {%- block footer %}
           {% include "footer.html" %}
       {% endblock %}

--- a/rtd_dropdown/integrations/disqus.html
+++ b/rtd_dropdown/integrations/disqus.html
@@ -1,0 +1,46 @@
+<!--
+  Copyright (c) 2016-2018 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Set from config but allow override -->
+{% set disqus = config.extra.disqus %}
+{% if page and page.meta and page.meta.disqus is string %}
+{% set disqus = page.meta.disqus %}
+{% endif %}
+
+<!-- Disqus integration -->
+{% if not page.is_homepage and disqus %}
+<h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+<div id="disqus_thread"></div>
+<script>
+    var disqus_config = function () {
+        this.page.url = "{{ page.canonical_url }}";
+        this.page.identifier =
+            "{{ page.canonical_url | replace(config.site_url, "") }}";
+    };
+    (function () {
+        var d = document, s = d.createElement("script");
+        s.src = "//{{ disqus }}.disqus.com/embed.js";
+        s.setAttribute("data-timestamp", +new Date());
+        (d.head || d.body).appendChild(s);
+    })();
+</script>
+{% endif %}


### PR DESCRIPTION
The source code is copied from [MkDocs Material](https://github.com/squidfunk/mkdocs-material)

Disqus plugin can be enabled by adding to following to `mkdocs.yml`
```yml
extra:
  disqus: 'your-shortname'
```
`site_url` must be set to enable the plugin